### PR TITLE
Update Taurus references to Chronos

### DIFF
--- a/pages/auto_agents_framework/introduction.mdx
+++ b/pages/auto_agents_framework/introduction.mdx
@@ -133,8 +133,8 @@ The framework integrates with the Autonomys Network for:
 
 1. Configure your `AUTO_DRIVE_API_KEY` in `.env` (obtain from https://ai3.storage)
 2. Enable Auto Drive uploading in `config.yaml`
-3. Provide your Taurus EVM wallet details (PRIVATE_KEY) and Agent Memory Contract Address (CONTRACT_ADDRESS) in `.env`
-4. Make sure your Taurus EVM wallet has funds. A faucet can be found at https://subspacefaucet.com/
+3. Provide your Chronos EVM wallet details (PRIVATE_KEY) and Agent Memory Contract Address (CONTRACT_ADDRESS) in `.env`
+4. Make sure your Chronos EVM wallet has funds. A faucet can be found at https://subspacefaucet.com/
 5. Provide encryption password in `.env` (optional, leave empty to not encrypt the agent memories)
 
 ### Resurrection (Memory Recovery)

--- a/pages/evm/NFT_guide.mdx
+++ b/pages/evm/NFT_guide.mdx
@@ -92,7 +92,7 @@ Click **transact** and confirm the transaction in MetaMask.
 
 ### Verification
 
-After the minting, the NFT will appear in the recipient’s wallet. You can verify the transfer using the [Block explorer for the Autonomys testnet](https://blockscout.taurus.autonomys.xyz/)
+After the minting, the NFT will appear in the recipient’s wallet. You can verify the transfer using the [Block explorer for the Autonomys testnet](https://explorer.auto-evm.chronos.autonomys.xyz//)
 
 **Here's how**:
 

--- a/pages/evm/block_explorer.mdx
+++ b/pages/evm/block_explorer.mdx
@@ -8,8 +8,8 @@ The **[Auto EVM domain block explorer](https://explorer.auto-evm.mainnet.autonom
 
  ![BlockExplorer-1](/developers/Auto-EVM-Block-Explorer.png)
 
-## Taurus Auto EVM Block Explorer
+## Chronos Auto EVM Block Explorer
 
-**[Taurus Auto EVM](https://blockscout.taurus.autonomys.xyz/)** domain block explorer. 
+**[Chronos Auto EVM](https://explorer.auto-evm.chronos.autonomys.xyz//)** domain block explorer. 
 
  ![BlockExplorer-2](/developers/BlockExplorer-1.png)

--- a/pages/evm/bridge.mdx
+++ b/pages/evm/bridge.mdx
@@ -1,15 +1,37 @@
 ---
-title: Bridging on the Chronos Testnet
+title: Bridging Assets
 ---
 
-# Bridging Now Possible on the Chronos Testnet
+# Bridging Assets with Autonomys
 
-We're excited to announce the deployment of a new Hyperlane-based bridge, developed in collaboration with our infrastructure partner Protofire. This bridge is now live on the Auto EVM domain of our Chronos testnet and accessible here: https://bridge.chronos.autonomys.xyz/
+We're excited to announce the deployment of Hyperlane-based bridges, developed in collaboration with our infrastructure partner Protofire. These bridges are now live on both mainnet and testnet environments.
 
 ![bridge](/developers/bridge-1.png)
 
-Bridges are critical infrastructure components for robust blockchain networks, enabling users to seamlessly access liquidity and applications across different blockchain ecosystems. With the launch of this HyperLane bridge, Autonomys users can now effortlessly transfer assets between the Chronos Auto EVM and Ethereum's Sepolia testnet as well as the Binance Smart Chain testnet, unlocking a broader range of possibilities and interactions.
+Bridges are critical infrastructure components for robust blockchain networks, enabling users to seamlessly access liquidity and applications across different blockchain ecosystems. With these Hyperlane bridges, Autonomys users can effortlessly transfer assets between networks, unlocking a broader range of possibilities and interactions.
 
-We encourage everyone in the community to explore this bridge and experiment with its capabilities. Your feedback is crucial as we continue to refine and improve our infrastructure.
+## Available Bridges
 
-Get involved and experience the power of seamless interoperability!
+### Mainnet Bridge
+
+**URL:** https://bridge.mainnet.autonomys.xyz/
+
+The mainnet bridge connects Autonomys mainnet with:
+- Ethereum mainnet
+- Binance Smart Chain mainnet
+
+### Chronos Testnet Bridge  
+
+**URL:** https://bridge.chronos.autonomys.xyz/
+
+The testnet bridge connects the Chronos Auto EVM domain with:
+- Ethereum's Sepolia testnet
+- Binance Smart Chain testnet
+
+This testnet environment is perfect for developers and users to experiment with cross-chain functionality without risking mainnet assets.
+
+## Get Started
+
+We encourage everyone in the community to explore these bridges and experiment with their capabilities. Your feedback is crucial as we continue to refine and improve our infrastructure.
+
+Experience the power of seamless interoperability across blockchain networks!

--- a/pages/evm/bridge.mdx
+++ b/pages/evm/bridge.mdx
@@ -1,16 +1,16 @@
 ---
-title: Bridging on the Taurus Testnet
+title: Bridging on the Chronos Testnet
 ---
 
-# Bridging Now Possible on the Taurus Testnet
+# Bridging Now Possible on the Chronos Testnet
 
-We're excited to announce the deployment of a new HyperLane-based bridge, developed in collaboration with our infrastructure partner Protofire. This bridge is now live on the Auto EVM domain of our Taurus testnet and accessible here: https://bridge.taurus.autonomys.xyz/
+We're excited to announce the deployment of a new HyperLane-based bridge, developed in collaboration with our infrastructure partner Protofire. This bridge is now live on the Auto EVM domain of our Chronos testnet and accessible here: https://bridge.taurus.autonomys.xyz/
 
 ![bridge](/developers/bridge-1.png)
 
-Bridges are critical infrastructure components for robust blockchain networks, enabling users to seamlessly access liquidity and applications across different blockchain ecosystems. With the launch of this HyperLane bridge, Autonomys users can now effortlessly transfer assets between the Taurus Auto EVM and Ethereum's Sepolia testnet, unlocking a broader range of possibilities and interactions.
+Bridges are critical infrastructure components for robust blockchain networks, enabling users to seamlessly access liquidity and applications across different blockchain ecosystems. With the launch of this HyperLane bridge, Autonomys users can now effortlessly transfer assets between the Chronos Auto EVM and Ethereum's Sepolia testnet, unlocking a broader range of possibilities and interactions.
 
-For those actively participating in our ongoing Game of Domains challenge -Crossing the Narrow Sea - you may already have a balance on Taurus Auto EVM. This means you're ready to jump right in and begin bridging your tokens over to Sepolia Ethereum without any additional steps.
+For those actively participating in our ongoing Game of Domains challenge -Crossing the Narrow Sea - you may already have a balance on Chronos Auto EVM. This means you're ready to jump right in and begin bridging your tokens over to Sepolia Ethereum without any additional steps.
 
 We encourage everyone in the community to explore this bridge and experiment with its capabilities. Your feedback is crucial as we continue to refine and improve our infrastructure.
 

--- a/pages/evm/bridge.mdx
+++ b/pages/evm/bridge.mdx
@@ -10,8 +10,6 @@ We're excited to announce the deployment of a new Hyperlane-based bridge, develo
 
 Bridges are critical infrastructure components for robust blockchain networks, enabling users to seamlessly access liquidity and applications across different blockchain ecosystems. With the launch of this HyperLane bridge, Autonomys users can now effortlessly transfer assets between the Chronos Auto EVM and Ethereum's Sepolia testnet as well as the Binance Smart Chain testnet, unlocking a broader range of possibilities and interactions.
 
-For those actively participating in our ongoing Game of Domains challenge -Crossing the Narrow Sea - you may already have a balance on Chronos Auto EVM. This means you're ready to jump right in and begin bridging your tokens over to Sepolia Ethereum without any additional steps.
-
 We encourage everyone in the community to explore this bridge and experiment with its capabilities. Your feedback is crucial as we continue to refine and improve our infrastructure.
 
 Get involved and experience the power of seamless interoperability!

--- a/pages/evm/bridge.mdx
+++ b/pages/evm/bridge.mdx
@@ -4,11 +4,11 @@ title: Bridging on the Chronos Testnet
 
 # Bridging Now Possible on the Chronos Testnet
 
-We're excited to announce the deployment of a new HyperLane-based bridge, developed in collaboration with our infrastructure partner Protofire. This bridge is now live on the Auto EVM domain of our Chronos testnet and accessible here: https://bridge.taurus.autonomys.xyz/
+We're excited to announce the deployment of a new Hyperlane-based bridge, developed in collaboration with our infrastructure partner Protofire. This bridge is now live on the Auto EVM domain of our Chronos testnet and accessible here: https://bridge.chronos.autonomys.xyz/
 
 ![bridge](/developers/bridge-1.png)
 
-Bridges are critical infrastructure components for robust blockchain networks, enabling users to seamlessly access liquidity and applications across different blockchain ecosystems. With the launch of this HyperLane bridge, Autonomys users can now effortlessly transfer assets between the Chronos Auto EVM and Ethereum's Sepolia testnet, unlocking a broader range of possibilities and interactions.
+Bridges are critical infrastructure components for robust blockchain networks, enabling users to seamlessly access liquidity and applications across different blockchain ecosystems. With the launch of this HyperLane bridge, Autonomys users can now effortlessly transfer assets between the Chronos Auto EVM and Ethereum's Sepolia testnet as well as the Binance Smart Chain testnet, unlocking a broader range of possibilities and interactions.
 
 For those actively participating in our ongoing Game of Domains challenge -Crossing the Narrow Sea - you may already have a balance on Chronos Auto EVM. This means you're ready to jump right in and begin bridging your tokens over to Sepolia Ethereum without any additional steps.
 

--- a/pages/evm/hardhat.mdx
+++ b/pages/evm/hardhat.mdx
@@ -119,7 +119,7 @@ For consistency, let's also rename `Lock.js` to `CounterTest.js`.
 
 Everything is working as expected so we're ready for deployment!
 
-8. To deploy the contract, we need to set a deployment network for `hardhat`. Open the `hardhat.config.js` file and add the Taurus testnet to the list of networks: 
+8. To deploy the contract, we need to set a deployment network for `hardhat`. Open the `hardhat.config.js` file and add the Chronos testnet to the list of networks: 
 
 ```
 require("@nomicfoundation/hardhat-toolbox");

--- a/pages/evm/introduction.mdx
+++ b/pages/evm/introduction.mdx
@@ -4,8 +4,6 @@ title: Auto EVM
 
 ## Auto EVM
 
-> *Note:* Auto EVM is currenty available exclusively on the **Chronos** testnet. Mainnet availability is planned for [**Mainnet Phase-2**](https://forum.autonomys.xyz/t/phased-launch-roadmap/4414).
-
 **Auto EVM** enables any tool available for Ethereum development to be compatible with the Autonomys Network.
 
 ### Quick Start Guide

--- a/pages/evm/introduction.mdx
+++ b/pages/evm/introduction.mdx
@@ -4,7 +4,7 @@ title: Auto EVM
 
 ## Auto EVM
 
-> *Note:* Auto EVM is currenty available exclusively on the **Taurus** testnet. Mainnet availability is planned for [**Mainnet Phase-2**](https://forum.autonomys.xyz/t/phased-launch-roadmap/4414).
+> *Note:* Auto EVM is currenty available exclusively on the **Chronos** testnet. Mainnet availability is planned for [**Mainnet Phase-2**](https://forum.autonomys.xyz/t/phased-launch-roadmap/4414).
 
 **Auto EVM** enables any tool available for Ethereum development to be compatible with the Autonomys Network.
 
@@ -25,7 +25,7 @@ Chain ID: 870
 Currency Symbol: AI3
 ```
 
-Auto EVM is also available on the Taurus testnet
+Auto EVM is also available on the Chronos testnet
 
 ```
 Network Name: Autonomys EVM

--- a/pages/evm/the_graph.mdx
+++ b/pages/evm/the_graph.mdx
@@ -4,7 +4,7 @@ title: The Graph
 
 # The Graph
 
-> **Note:** Available on both **Mainnet** and **Taurus** testnet!
+> **Note:** Available on both **Mainnet** and **Chronos** testnet!
 
 
 [The Graph](https://thegraph.com/) is an indexing protocol that provides an easy way to query blockchain data through decentralized APIs known as subgraphs. 
@@ -62,7 +62,7 @@ During the initialization, you will need to specify a few things:
 - Network (Autonomys)
 - Subgraph slug (feel free to use the default name)
 - Directory to create the subgraph in (feel free to use the default directory)
-- Smart contact address (the address of your smart contract deployed on Autonomys Taurus EVM domain)
+- Smart contact address (the address of your smart contract deployed on Autonomys Chronos EVM domain)
 - ABI file (path)
 - Start block (feel free to use the default value)
 - Contract name

--- a/pages/introduction.mdx
+++ b/pages/introduction.mdx
@@ -61,21 +61,15 @@ To start using the Auto EVM, refer to our [guides and manuals](/evm/introduction
 
 #### Consensus
 - `wss://rpc.mainnet.subspace.foundation/ws`
-- `wss://rpc.taurus.autonomys.xyz/ws`
+- `wss://rpc.chronos.autonomys.xyz/ws`
 
 ### Auto EVM
 
 #### Mainnet
 - `wss://auto-evm.mainnet.autonomys.xyz/ws`
 
-#### Taurus Testnet
-- `wss://auto-evm.taurus.autonomys.xyz/ws`
-
-### Auto ID
-
-> **Note:** Available on the **Gemini-3h** testnet
-
-- `wss://autoid-0.gemini-3h.subspace.network/ws`
+#### Chronos Testnet
+- `wss://auto-evm.chronos.autonomys.xyz/ws`
 
 ## Questions or feedback? Post on our [forum](https://forum.autonomys.xyz/) or in the *#developer-chat* channel on our [Discord](https://discord.gg/EAw6B48r).
 

--- a/pages/sdk/auto-xdm.mdx
+++ b/pages/sdk/auto-xdm.mdx
@@ -90,7 +90,7 @@ import { transferToDomainAccount20Type } from '@autonomys/auto-xdm'
 const api = await activateWallet({ networkId: 'taurus', uri: '//alice' })
 const tx = await transferToDomainAccount20Type(
   api,
-  0, // Receiver domain (0 is Auto EVM on Taurus Testnet)
+  0, // Receiver domain (0 is Auto EVM on Chronos Testnet)
   '0x1234567890abcdef', // Receiver domain account
   '1000000000000000000',
 )
@@ -106,7 +106,7 @@ import { transferToDomainAccount32Type } from '@autonomys/auto-xdm'
 const api = await activateWallet({ networkId: 'taurus', uri: '//alice' })
 const tx = await transferToDomainAccount32Type(
   api,
-  0, // Receiver domain (0 is Auto EVM on Taurus Testnet)
+  0, // Receiver domain (0 is Auto EVM on Chronos Testnet)
   'su1234567890abcdef', // Receiver domain account
   '1000000000000000000',
 )
@@ -137,7 +137,7 @@ import { domainBalances } from '@autonomys/auto-xdm';
     networkId: 'taurus' 
   });
 
-  // Get balances for domain 0 (Auto EVM on the Taurus testnet)
+  // Get balances for domain 0 (Auto EVM on the Chronos testnet)
   const balances = await domainBalances(api, 0);
   console.log('Domain balances:', balances.toString());
 })();


### PR DESCRIPTION
This PR updates Taurus referenced to Chronos (partially).

Some references to Taurus are left out where Chronos infrastructure is not yet available, e.g. Auto Drive 