### PR TITLE
docs(s3): point S3 endpoint at dedicated subdomain

### DIFF
--- a/pages/auto_drive/rclone.mdx
+++ b/pages/auto_drive/rclone.mdx
@@ -45,7 +45,7 @@ type = s3
 provider = Other
 access_key_id = YOUR_API_KEY_HERE
 secret_access_key = placeholder
-endpoint = https://public.auto-drive.autonomys.xyz/s3
+endpoint = https://s3.auto-drive.autonomys.xyz
 no_check_bucket = true
 list_version = 2
 ```
@@ -73,7 +73,7 @@ rclone copy autodrive:my-archive/my-file.txt ./downloaded/
 | `provider` | `Other` | Generic S3-compatible mode — no provider-specific assumptions |
 | `access_key_id` | Your Auto Drive API key | From the **Developers** tab at [ai3.storage](https://ai3.storage) |
 | `secret_access_key` | Any non-empty string | Required by rclone but ignored by Auto Drive |
-| `endpoint` | `https://public.auto-drive.autonomys.xyz/s3` | Auto Drive S3 API base URL |
+| `endpoint` | `https://s3.auto-drive.autonomys.xyz` | Auto Drive S3 API base URL |
 | `no_check_bucket` | `true` | Skip bucket existence check — buckets are created implicitly on first write |
 | `list_version` | `2` | **Required.** Auto Drive implements ListObjectsV2 only; without this, rclone defaults to V1 and listings fail |
 
@@ -97,7 +97,7 @@ rclone config
 4. Select `Other` as the provider
 5. Enter your API key as `access_key_id`
 6. Enter `placeholder` for `secret_access_key`
-7. Enter `https://public.auto-drive.autonomys.xyz/s3` as the endpoint
+7. Enter `https://s3.auto-drive.autonomys.xyz` as the endpoint
 8. Accept defaults for the remaining options
 
 Then manually add `no_check_bucket = true` and `list_version = 2` to the config section.
@@ -438,7 +438,7 @@ jobs:
           provider = Other
           access_key_id = ${{ secrets.AUTO_DRIVE_API_KEY }}
           secret_access_key = placeholder
-          endpoint = https://public.auto-drive.autonomys.xyz/s3
+          endpoint = https://s3.auto-drive.autonomys.xyz
           no_check_bucket = true
           list_version = 2
           EOF
@@ -466,7 +466,7 @@ archive-artifacts:
       provider = Other
       access_key_id = ${AUTO_DRIVE_API_KEY}
       secret_access_key = placeholder
-      endpoint = https://public.auto-drive.autonomys.xyz/s3
+      endpoint = https://s3.auto-drive.autonomys.xyz
       no_check_bucket = true
       list_version = 2
       EOF
@@ -530,7 +530,7 @@ services:
         provider = Other
         access_key_id = $${AUTO_DRIVE_API_KEY}
         secret_access_key = placeholder
-        endpoint = https://public.auto-drive.autonomys.xyz/s3
+        endpoint = https://s3.auto-drive.autonomys.xyz
         no_check_bucket = true
         list_version = 2
         EOF
@@ -618,7 +618,7 @@ ERROR : file.txt: Failed to delete: 403 Access Denied: Auto Drive storage is imm
 
 **Fix:**
 
-- `curl -I https://public.auto-drive.autonomys.xyz/s3` to verify reachability
+- `curl -I https://s3.auto-drive.autonomys.xyz` to verify reachability
 - Increase the timeout: `--timeout=60s`
 - Add retries: `--retries=5 --retries-sleep=10s`
 
@@ -646,7 +646,7 @@ ERROR : file.txt: Failed to delete: 403 Access Denied: Auto Drive storage is imm
 rclone config show autodrive
 
 # Test endpoint reachability
-curl -I https://public.auto-drive.autonomys.xyz/s3
+curl -I https://s3.auto-drive.autonomys.xyz
 
 # Verbose upload with full logging
 rclone copy ./test.txt autodrive:test-bucket/ \

--- a/pages/sdk/auto-drive/s3_layer.mdx
+++ b/pages/sdk/auto-drive/s3_layer.mdx
@@ -180,7 +180,7 @@ console.log(result.ETag); // '"<composite_md5>-1"'
 
 | Environment | Endpoint |
 | --- | --- |
-| **Mainnet (public)** | `https://public.auto-drive.autonomys.xyz/s3` |
+| **Mainnet (public)** | `https://s3.auto-drive.autonomys.xyz` |
 
 ### Client Setup (AWS JS SDK)
 
@@ -191,7 +191,7 @@ import { S3Client } from "@aws-sdk/client-s3";
 
 const s3Client = new S3Client({
   region: "us-east-1",                                // required by the SDK; ignored by Auto Drive
-  endpoint: "https://public.auto-drive.autonomys.xyz/s3",
+  endpoint: "https://s3.auto-drive.autonomys.xyz",
   credentials: {
     accessKeyId: "your-auto-drive-api-key",          // your Auto Drive API key
     secretAccessKey: "placeholder",                   // any non-empty string; ignored
@@ -249,7 +249,7 @@ For the dedicated walkthrough — quickstart, full config reference, every suppo
 
 For developers moving from traditional AWS S3:
 
-1. **Update the endpoint** to `https://public.auto-drive.autonomys.xyz/s3`
+1. **Update the endpoint** to `https://s3.auto-drive.autonomys.xyz`
 2. **Change credentials** to use your Auto Drive API key as `accessKeyId`; set `secretAccessKey` to a placeholder
 3. **Set `forcePathStyle: true`** in the S3 client configuration
 4. **Drop bucket-creation calls** — buckets are created implicitly on first write
@@ -270,7 +270,7 @@ const s3Client = new S3Client({
 // After (Auto Drive)
 const s3Client = new S3Client({
   region: "us-east-1",
-  endpoint: "https://public.auto-drive.autonomys.xyz/s3",
+  endpoint: "https://s3.auto-drive.autonomys.xyz",
   credentials: {
     accessKeyId: "your-auto-drive-api-key",
     secretAccessKey: "placeholder",


### PR DESCRIPTION
## What

The S3-compatible API now has its own dedicated subdomain, replacing the clumsy `/s3` path. Update the advertised endpoint across the docs:

`https://public.auto-drive.autonomys.xyz/s3` → **`https://s3.auto-drive.autonomys.xyz`**

- `pages/sdk/auto-drive/s3_layer.mdx` — endpoint table, AWS SDK examples, rclone section (×4)
- `pages/auto_drive/rclone.mdx` — rclone config examples, reference table, verification commands (×8)

The local-dev example (`http://localhost:3000/s3`) is intentionally left unchanged. The legacy `/s3` path still works, so this is purely a docs/advertising change.

Part of autonomys/auto-drive#762 (subdomain is live + deployed).

## ⚠️ Note: `llm_friendly_docs.mdx` drift detected

While making this change I noticed `pages/llm_friendly_docs.mdx` (the generated aggregate from `scripts/combineDocs.js`) is **significantly stale** versus the source pages — e.g. it still advertises an old `…/api/s3` S3 endpoint that no longer exists in any source page.

I deliberately **did not** touch it here: it regenerates on `prebuild`/`vercel-build`, and regenerating it locally produced a ~9,200-line diff of unrelated content drift — far outside the scope of this S3 change. So it'll pick up the new endpoint automatically at the next build.

But the size of that drift suggests **the committed copy is well behind the sources and may be due for a refresh** (a standalone `node scripts/combineDocs.js` commit), so the in-repo aggregate matches what actually ships. Flagging for a separate cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
