### PR TITLE
docs(safe): warn against transferring to exchanges from a Safe

### DIFF
--- a/pages/evm/safe.mdx
+++ b/pages/evm/safe.mdx
@@ -6,6 +6,8 @@ Safe (formerly Gnosis Safe) is now available on the Autonomys network, providing
 
 Safe is a battle-tested smart contract wallet infrastructure that enables multi-signature security across blockchain networks. With its deployment on Autonomys, teams, DAOs, and individual users can now benefit from enhanced security features and shared asset control on both our mainnet and testnet environments.
 
+> **⚠️ Do not transfer directly to a centralized exchange from a Safe.** A Safe is a smart contract wallet, not a standard externally owned account (EOA). Many centralized exchanges do not support deposits originating from smart contract wallets, and funds sent from a Safe to an unsupported exchange deposit address can be lost or require a manual, time-consuming recovery process. Before sending any assets from a Safe on Autonomys to an exchange, confirm with that exchange that it supports deposits from smart contract (Safe) wallets. If you are unsure, first move the funds to a standard wallet address you control and deposit from there.
+
 ## Network Availability
 
 Safe is currently deployed and accessible at: [https://safe.autonomys.xyz](https://safe.autonomys.xyz/welcome)


### PR DESCRIPTION
## Summary

Adds a prominent warning callout to the Safe documentation page advising users **not to transfer funds directly to a centralized exchange deposit address from a Safe** without first checking the exchange's support policy.

This follows feedback from an exchange that they do not support deposits originating from Safe (smart contract) wallets — a limitation common to many centralized exchanges.

## What changed

- [pages/evm/safe.mdx](pages/evm/safe.mdx): new callout (using the repo's existing `> **Note:**` blockquote convention) directly after the Overview intro.

The note explains the *why* (a Safe is a smart contract wallet, not an EOA), the *risk* (funds can be lost or require manual recovery), and the *action* (confirm the exchange supports Safe deposits first, or route through an EOA you control).

🤖 Generated with [Claude Code](https://claude.com/claude-code)