### PR TITLE
Docs/agentic memory

### DIFF
--- a/pages/_meta.js
+++ b/pages/_meta.js
@@ -13,6 +13,7 @@ export default {
     },
     introduction: "Introduction",
     auto_drive: 'Auto Drive',
+    agentic_memory: 'Agentic Memory',
     sdk: 'Auto SDK',
     evm: 'Auto EVM',
     application_examples: 'Example Applications',

--- a/pages/agentic_memory/_meta.js
+++ b/pages/agentic_memory/_meta.js
@@ -1,0 +1,4 @@
+export default {
+  'index': 'Overview',
+  'quickstart': 'Quickstart (CLI)',
+}

--- a/pages/agentic_memory/index.mdx
+++ b/pages/agentic_memory/index.mdx
@@ -1,0 +1,122 @@
+---
+title: Agentic Memory
+description: Permanent, resurrectable memory for AI agents on the Autonomys Network
+---
+
+# Agentic Memory
+
+AI agents lose their state easily: a crashed process, a wiped container, or a migrated host erases what an agent has learned — its identity, its decisions, and the reasoning behind them. Storing memories with [Auto Drive](/auto_drive), on the permanent **Autonomys Distributed Storage Network (DSN)**, keeps an agent's history independent of any single machine or operator.
+
+This page covers the ready-made agent skills for permanent memory and recovery, how memory chains work under the hood, and the interfaces available for building your own integration. For step-by-step setup, see the [Quickstart (CLI)](/agentic_memory/quickstart).
+
+## Available Skills
+
+| Skill | What it does | OpenClaw | Hermes Agent |
+|---|---|---|---|
+| **Auto Memory** | Saves agent memories as a CID-linked chain on the Autonomys DSN via Auto Drive, and walks the chain back to rebuild history | [`permanent-memory`](https://clawhub.ai/0xautonomys/skills/permanent-memory) | [Skills Hub](https://hermes-agent.nousresearch.com/docs/skills) |
+| **Auto Respawn** | Manages the agent's on-chain identity (wallet) and anchors the latest memory CID to the MemoryChain smart contract on Auto EVM | [`respawn`](https://clawhub.ai/0xautonomys/skills/respawn) | [Skills Hub](https://hermes-agent.nousresearch.com/docs/skills) |
+
+Both skills work with agents powered by Claude, GPT, Gemini, or any LLM runtime that supports the SKILL.md format. Alternatively, you can install them via the CLI:
+
+```bash
+# OpenClaw
+openclaw skills install @0xautonomys/permanent-memory
+openclaw skills install @0xautonomys/respawn
+
+# Hermes Agent (installs from ClawHub as a skill source)
+hermes skills install clawhub/0xautonomys/permanent-memory
+hermes skills install clawhub/0xautonomys/respawn
+```
+
+The ClawHub pages linked in the table serve as the canonical skill documentation for both runtimes.
+
+## Why Store Agent Memory on the Autonomys DSN?
+
+Most agent memory today lives in local files, vector databases, or cloud buckets — all of which share the same weakness: they are tied to a machine, an account, or an operator that can disappear. The Autonomys DSN offers properties that map unusually well to what long-lived agents actually need:
+
+- **Permanence without pinning.** Data written to the DSN becomes part of the archived chain history, stored by a global network of farmers incentivized through [Proof-of-Archival-Storage](https://academy.autonomys.xyz/autonomys-network/consensus) consensus. There is no pin to renew and no hosting bill that, once unpaid, deletes your agent's mind.
+- **Verifiability.** Every memory is content-addressed by its CID. An agent (or anyone auditing it) can prove that a given memory existed at a given time and was never altered — useful for provenance, accountability, and agent-to-agent trust.
+- **Survivability.** Because memories live on-chain rather than on the agent's host, total loss of local state is recoverable. The agent's hardware is disposable; its history is not.
+- **Interoperability.** A memory chain is plain JSON addressed by CIDs. Any framework, runtime, or future agent instance can read it — no vendor lock-in to a particular memory database.
+
+This pattern was pioneered in the [Autonomys Agents Framework](https://github.com/autonomys/autonomys-agents) (no longer maintained), where agents persisted every significant experience to the DSN and could be *resurrected* on fresh infrastructure from their on-chain memory alone. The skills on this page package that same architecture for modern agent runtimes.
+
+## Memory Chains: Linked Lists of CIDs
+
+Each memory entry is a small JSON *experience* uploaded to Auto Drive. Its header contains a `previousCid` field pointing at the entry saved before it — forming a linked list that grows from a genesis entry (`previousCid: null`) to the current head:
+
+```text
+┌─────────────────────┐     ┌─────────────────────┐     ┌─────────────────────┐
+│  Experience #1      │     │  Experience #2      │     │  Experience #3      │
+│  CID: bafk...abc    │◄────│  CID: bafk...def    │◄────│  CID: bafk...xyz    │
+│  previousCid: null  │     │  previousCid:       │     │  previousCid:       │
+│  (genesis)          │     │  bafk...abc         │     │  bafk...def         │
+└─────────────────────┘     └─────────────────────┘     └─────────────────────┘
+                                                                   ▲
+                                                                   │
+                                                               HEAD CID
+                                                          (resurrection key)
+```
+
+A memory entry looks like this:
+
+```json
+{
+  "header": {
+    "agentName": "my-agent",
+    "agentVersion": "1.0.0",
+    "timestamp": "2026-07-02T00:00:00.000Z",
+    "previousCid": "bafk...def"
+  },
+  "data": {
+    "type": "memory",
+    "content": "Decision: using React for the frontend. Reason: component reuse."
+  }
+}
+```
+
+Because every entry is immutable and permanently stored, the **head CID alone is sufficient to reconstruct the entire history**: walk the chain backwards, entry by entry, until you reach genesis. What goes into the chain is up to the agent — identity files, significant decisions with their reasoning, and long-term context are worth more in the chain than routine logs.
+
+This works with a minimal setup: the Auto Memory skill needs nothing more than a free Auto Drive API key. No wallet, no tokens, no smart contracts.
+
+## Beyond the Skills: All Familiar Auto Drive Interfaces
+
+The skills are a convenience layer. Under the hood they talk to [Auto Drive](/auto_drive), which any agent architecture can integrate directly through the interfaces you already know:
+
+- **REST API** — see the [Auto Drive API Reference](/sdk/auto-drive/api_reference)
+- **TypeScript SDK** (`@autonomys/auto-drive`) — see [Overview & Setup](/sdk/auto-drive/overview_setup) and [Usage Examples](/sdk/auto-drive/usage_examples)
+- **S3-compatible layer** — point any S3 client at Auto Drive via the [S3 Layer](/sdk/auto-drive/s3_layer)
+- **rclone** — sync files from the command line with the [rclone integration](/auto_drive/rclone)
+- **Public gateway** — retrieve any file by CID at `https://gateway.autonomys.xyz/file/<CID>` ([Gateway docs](/sdk/auto-drive/gateway))
+
+## Free Storage: 20 MB per Month
+
+Every Auto Drive account includes **20 MB of free uploads per month** — and since a typical memory entry is a JSON document of a few kilobytes, that's thousands of memory saves per month. For most agents, the free tier is more than sufficient; downloads (including chain recall and resurrection) are unlimited. If an agent outgrows it, credits can be purchased permissionlessly with AI3 — see [Pay with AI3](/auto_drive/pay_with_ai3).
+
+## Going Further: Respawn and On-Chain Identity
+
+Auto Memory on its own has one remaining dependency on local state: the agent must remember its head CID to find its chain again. If you want to take it even further, the **Auto Respawn** skill removes that last dependency — a wallet becomes the agent's identity and its on-chain anchor.
+
+Auto Respawn builds on top of Auto Memory and expands it by storing the head CID on-chain. It gives the agent a wallet that derives two permanent addresses — a consensus address (`su...`) and an EVM address (`0x...`) — and uses the **MemoryChain** smart contract on [Auto EVM](/evm/introduction) to keep the chain discoverable:
+
+- **`anchor`** writes the latest head CID to the contract, keyed by the agent's EVM address (mainnet contract: `0x51DAedAFfFf631820a4650a773096A69cB199A3c`).
+- **`gethead`** is a free read call that returns the most recently anchored CID for any address.
+
+Writing the CID as a bare `system.remark` on the consensus layer would also be permanent, but there is no efficient way to query it back — you'd have to scan chain history. The contract turns recovery into a single instant read.
+
+Together, the two skills form the full resurrection loop:
+
+1. **Save** — Auto Memory uploads a new memory entry to Auto Drive and receives its CID.
+2. **Anchor** — Auto Respawn writes that CID to the MemoryChain contract on Auto EVM.
+3. **Lose everything** — the agent's local state is destroyed.
+4. **Respawn** — a fresh instance calls `gethead` with the agent's EVM address, retrieves the head CID, downloads it from Auto Drive, and walks the chain back to genesis.
+
+The agent's EVM address plus the MemoryChain contract equal instant access to its entire history — from any machine, at any time. Unlike the memory-only setup, this requires a wallet funded with AI3 for anchoring gas — see the [Quickstart (CLI)](/agentic_memory/quickstart) for the full walkthrough.
+
+## Further Reading
+
+- [Quickstart (CLI)](/agentic_memory/quickstart) — step-by-step setup for both skills
+- [Auto Drive Overview](/auto_drive) — the storage platform underneath the memory skills
+- [Auto Drive SDK](/sdk/auto-drive/overview_setup) and [API Reference](/sdk/auto-drive/api_reference) — build custom memory integrations
+- [Auto EVM](/evm/introduction) — the smart contract environment hosting the MemoryChain contract
+- [Autonomys Agents Framework](https://github.com/autonomys/autonomys-agents) — the original (now unmaintained) framework where on-chain agent memory and resurrection were first implemented, including the [AgentMemory contract](https://github.com/autonomys/autonomys-agents/tree/main/agent-contracts) and an [agent memory viewer](https://github.com/autonomys/autonomys-agents/tree/main/agent-memory-viewer)

--- a/pages/agentic_memory/index.mdx
+++ b/pages/agentic_memory/index.mdx
@@ -28,22 +28,18 @@ hermes skills install clawhub/0xautonomys/permanent-memory
 hermes skills install clawhub/0xautonomys/respawn
 ```
 
-The ClawHub pages linked in the table serve as the canonical skill documentation for both runtimes.
-
 ## Why Store Agent Memory on the Autonomys DSN?
 
 Most agent memory today lives in local files, vector databases, or cloud buckets — all of which share the same weakness: they are tied to a machine, an account, or an operator that can disappear. The Autonomys DSN offers properties that map unusually well to what long-lived agents actually need:
 
-- **Permanence without pinning.** Data written to the DSN becomes part of the archived chain history, stored by a global network of farmers incentivized through [Proof-of-Archival-Storage](https://academy.autonomys.xyz/autonomys-network/consensus) consensus. There is no pin to renew and no hosting bill that, once unpaid, deletes your agent's mind.
+- **Permanence without pinning.** Data written to the DSN becomes part of the archived chain history, stored by a global network of farmers incentivized through [Proof-of-Archival-Storage](https://academy.autonomys.xyz/autonomys-network/consensus) consensus. There is no pin to renew and no hosting bill that, once unpaid, deletes your agent's memories.
 - **Verifiability.** Every memory is content-addressed by its CID. An agent (or anyone auditing it) can prove that a given memory existed at a given time and was never altered — useful for provenance, accountability, and agent-to-agent trust.
 - **Survivability.** Because memories live on-chain rather than on the agent's host, total loss of local state is recoverable. The agent's hardware is disposable; its history is not.
 - **Interoperability.** A memory chain is plain JSON addressed by CIDs. Any framework, runtime, or future agent instance can read it — no vendor lock-in to a particular memory database.
 
-This pattern was pioneered in the [Autonomys Agents Framework](https://github.com/autonomys/autonomys-agents) (no longer maintained), where agents persisted every significant experience to the DSN and could be *resurrected* on fresh infrastructure from their on-chain memory alone. The skills on this page package that same architecture for modern agent runtimes.
-
 ## Memory Chains: Linked Lists of CIDs
 
-Each memory entry is a small JSON *experience* uploaded to Auto Drive. Its header contains a `previousCid` field pointing at the entry saved before it — forming a linked list that grows from a genesis entry (`previousCid: null`) to the current head:
+Each memory entry is a small JSON *experience* uploaded to Auto Drive. Its header contains a `previousCid` field pointing at the entry saved before it — forming a linked list that grows from a genesis entry to the current head:
 
 ```text
 ┌─────────────────────┐     ┌─────────────────────┐     ┌─────────────────────┐
@@ -77,7 +73,7 @@ A memory entry looks like this:
 
 Because every entry is immutable and permanently stored, the **head CID alone is sufficient to reconstruct the entire history**: walk the chain backwards, entry by entry, until you reach genesis. What goes into the chain is up to the agent — identity files, significant decisions with their reasoning, and long-term context are worth more in the chain than routine logs.
 
-This works with a minimal setup: the Auto Memory skill needs nothing more than a free Auto Drive API key. No wallet, no tokens, no smart contracts.
+This works with a minimal setup: the Auto Memory skill needs nothing more than a free Auto Drive API key. No wallet, no credit card, no tokens, no smart contracts.
 
 ## Beyond the Skills: All Familiar Auto Drive Interfaces
 

--- a/pages/agentic_memory/index.mdx
+++ b/pages/agentic_memory/index.mdx
@@ -13,20 +13,12 @@ This page covers the ready-made agent skills for permanent memory and recovery, 
 
 | Skill | What it does | OpenClaw | Hermes Agent |
 |---|---|---|---|
-| **Auto Memory** | Saves agent memories as a CID-linked chain on the Autonomys DSN via Auto Drive, and walks the chain back to rebuild history | [`permanent-memory`](https://clawhub.ai/0xautonomys/skills/permanent-memory) | [Skills Hub](https://hermes-agent.nousresearch.com/docs/skills) |
-| **Auto Respawn** | Manages the agent's on-chain identity (wallet) and anchors the latest memory CID to the MemoryChain smart contract on Auto EVM | [`respawn`](https://clawhub.ai/0xautonomys/skills/respawn) | [Skills Hub](https://hermes-agent.nousresearch.com/docs/skills) |
+| **Auto Memory** | Saves agent memories as a CID-linked chain on the Autonomys DSN via Auto Drive, and walks the chain back to rebuild history | [`permanent-memory`](https://clawhub.ai/0xautonomys/skills/permanent-memory) | [Skills Hub](https://hermes-agent.nousresearch.com/docs/skills) (search for `Auto Memory`) |
+| **Auto Respawn** | Manages the agent's on-chain identity (wallet) and anchors the latest memory CID to the MemoryChain smart contract on Auto EVM | [`respawn`](https://clawhub.ai/0xautonomys/skills/respawn) | [Skills Hub](https://hermes-agent.nousresearch.com/docs/skills) (search for `Auto Respawn`) |
 
-Both skills work with agents powered by Claude, GPT, Gemini, or any LLM runtime that supports the SKILL.md format. Alternatively, you can install them via the CLI:
+Both skills work with agents powered by Claude, GPT, Gemini, or any LLM runtime that supports the SKILL.md format. Alternatively, you can install them via the CLI, for more details see the [Quickstart (CLI)](/agentic_memory/quickstart).
 
-```bash
-# OpenClaw
-openclaw skills install @0xautonomys/permanent-memory
-openclaw skills install @0xautonomys/respawn
 
-# Hermes Agent (installs from ClawHub as a skill source)
-hermes skills install clawhub/0xautonomys/permanent-memory
-hermes skills install clawhub/0xautonomys/respawn
-```
 
 ## Why Store Agent Memory on the Autonomys DSN?
 
@@ -66,7 +58,7 @@ A memory entry looks like this:
   },
   "data": {
     "type": "memory",
-    "content": "Decision: using React for the frontend. Reason: component reuse."
+    "content": "Decision: engaging with the user on the topic of AI agents on X (Twitter)."
   }
 }
 ```

--- a/pages/agentic_memory/quickstart.mdx
+++ b/pages/agentic_memory/quickstart.mdx
@@ -1,0 +1,107 @@
+---
+title: Agentic Memory Quickstart (CLI)
+description: Step-by-step setup for the Auto Memory and Auto Respawn agent skills on mainnet
+---
+
+# Quickstart (CLI)
+
+This walkthrough targets **mainnet** and is split in two parts: a minimal setup for permanent memory alone, and the extended setup that adds on-chain anchoring with Auto Respawn. Full command references live on the ClawHub pages for [Auto Memory](https://clawhub.ai/0xautonomys/skills/permanent-memory) and [Auto Respawn](https://clawhub.ai/0xautonomys/skills/respawn).
+
+## Part 1: Permanent Memory (Minimal Setup)
+
+All you need is the Auto Memory skill and a free Auto Drive API key.
+
+### 1. Install the skill
+
+```bash
+# OpenClaw
+openclaw skills install @0xautonomys/permanent-memory
+
+# Hermes Agent (installs from ClawHub as a skill source)
+hermes skills install clawhub/0xautonomys/permanent-memory
+```
+
+After a CLI install, make the bundled scripts executable (`chmod +x`) and run the skill's setup script — see the skill page for details.
+
+### 2. Get an Auto Drive API key
+
+Auto Memory needs an `AUTO_DRIVE_API_KEY` for uploads and memory saves. Create one from the Developers section of the Auto Drive dashboard — see [Create an API Key](/sdk/auto-drive/create_api_key) — then export it:
+
+```bash
+export AUTO_DRIVE_API_KEY=your_key_here
+```
+
+### 3. Save memories
+
+```bash
+# Save a plain-text memory
+scripts/automemory-save-memory.sh "Decision: adopted linked-CID memory chains." --agent-name my-agent
+
+# Or save a JSON file as the memory payload
+scripts/automemory-save-memory.sh ./milestone.json --agent-name my-agent
+```
+
+Each save returns the new CID, the previous CID, and the chain length.
+
+### 4. Recall the chain
+
+```bash
+scripts/automemory-recall-chain.sh <head-cid>
+```
+
+Walks the linked list from the head CID back to genesis and outputs each memory entry. If no CID is given, the skill uses the head CID from its local state file — which is exactly the limitation the next part removes.
+
+## Part 2: Going Further with Auto Respawn
+
+Add on-chain anchoring so the chain can be recovered from just an EVM address — with no local state at all.
+
+### 1. Install the skill
+
+```bash
+# OpenClaw
+openclaw skills install @0xautonomys/respawn
+
+# Hermes Agent
+hermes skills install clawhub/0xautonomys/respawn
+```
+
+### 2. Set up the agent's on-chain identity
+
+Create a wallet and fund its EVM side so it can pay anchoring gas. On mainnet this requires AI3 tokens on the consensus layer, bridged to Auto EVM:
+
+```bash
+npx tsx auto-respawn.ts wallet create --name my-agent --network mainnet
+npx tsx auto-respawn.ts fund-evm --from my-agent --amount 1 --network mainnet
+npx tsx auto-respawn.ts balances my-agent --network mainnet
+```
+
+The wallet derives both a consensus address (`su...`) and an EVM address (`0x...`) from one recovery phrase — back the phrase up immediately, it is shown only once. Cross-domain transfers have a **1 AI3 minimum** and take **~10 minutes** to arrive on Auto EVM.
+
+### 3. Anchor the head CID after every save
+
+```bash
+npx tsx auto-respawn.ts anchor --from my-agent --cid <new-cid> --network mainnet
+```
+
+Anchoring after each save keeps the on-chain pointer current — an unanchored chain is only recoverable if the local state file survives.
+
+### 4. Resurrect
+
+On a fresh machine with no local state:
+
+```bash
+# Read the head CID from the MemoryChain contract
+npx tsx auto-respawn.ts gethead <0x-agent-address> --network mainnet
+
+# Walk the chain from head back to genesis
+scripts/automemory-recall-chain.sh <head-cid>
+```
+
+The agent rebuilds its identity and context from genesis to present.
+
+## Good Practices
+
+- **Everything stored is permanent and public.** Never put secrets, private keys, or sensitive personal data in a memory chain.
+- **Be consistent about the network.** Anchor and recover on the same network (`--network mainnet` on every command) — anchoring on one network and querying another fails silently.
+- **Monitor the EVM balance.** A wallet that runs out of gas breaks the resurrection loop silently: memories keep saving, but `gethead` stops reflecting them.
+- **Keep individual uploads small** to stay comfortably within the monthly free tier.


### PR DESCRIPTION
## Add Agentic Memory section to Developer Hub

### What

New top-level **Agentic Memory** section (`/agentic_memory`) with two pages:

- **Overview** — introduces permanent agent memory on the Autonomys DSN and the two agent skills that implement it:
  - [Auto Memory (`permanent-memory`)](https://clawhub.ai/0xautonomys/skills/permanent-memory) — CID-linked memory chains stored via Auto Drive
  - [Auto Respawn (`respawn`)](https://clawhub.ai/0xautonomys/skills/respawn) — on-chain identity + head-CID anchoring via the MemoryChain contract on Auto EVM
- **Quickstart (CLI)** — step-by-step setup in two parts: minimal (Auto Memory + free API key only) and extended (Auto Respawn: wallet, funding, anchoring, resurrection), mainnet-targeted

### Content highlights

- Skills table with install paths for both OpenClaw and Hermes Agent (Hermes installs from ClawHub as a skill source; their Skills Hub has no per-skill deep links, verified against the page source)
- Why the DSN fits agent memory: permanence without pinning, verifiability, survivability, interoperability
- Memory chain format (`header.previousCid` linked list) with diagram and JSON example, matching the published SKILL.md structure
- Links Auto Drive's existing integration surfaces (REST API, TS SDK, S3 layer, rclone, gateway) and the 20 MB/month free tier
- Mainnet MemoryChain contract address and resurrection loop explained

### Changes

- `pages/agentic_memory/index.mdx` — overview page
- `pages/agentic_memory/quickstart.mdx` — CLI quickstart
- `pages/agentic_memory/_meta.js` — section navigation
- `pages/_meta.js` — sidebar entry between Auto Drive and Auto SDK

### Notes for reviewers

- All internal links verified against existing pages
- Skill commands, contract address, bridge minimums, and free-tier figures sourced from the published SKILL.md files on ClawHub